### PR TITLE
refactor: remove outdate crate json

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set Up Dependencies
-      run: sudo apt-get install -y gdb
+      run: sudo apt-get update && sudo apt-get install -y gdb
     - name: Build
       run: cargo build
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,12 +1192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,7 +1308,6 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenv",
- "json",
  "mcp-core",
  "mcp-core-macros",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ mcp-core = { version = "0.1",  features = ["sse"] }
 mcp-core-macros = "0.1"
 schemars = "0.8"
 nom = "8.0"
-json = "0.12"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29.0", features = ["process", "signal"] }

--- a/src/gdb.rs
+++ b/src/gdb.rs
@@ -103,14 +103,10 @@ impl GDBManager {
                     let transport = TRANSPORT.lock().await;
                     if let Some(transport) = transport.as_ref() {
                         if let Err(e) = transport
-                            .send_notification("create_session", Some(json!(results.dump())))
+                            .send_notification("create_session", Some(results))
                             .await
                         {
-                            tracing::error!(
-                                "Failed to send ping to session {}: {:?}",
-                                results.dump(),
-                                e
-                            );
+                            tracing::error!("Failed to send ping to session: {:?}", e);
                         }
                     } else {
                         break;
@@ -204,7 +200,7 @@ impl GDBManager {
             .ok_or_else(|| AppError::NotFound(format!("Session {} does not exist", session_id)))?;
 
         let record = handle.gdb.execute(command).await?;
-        let output = record.results.dump();
+        let output = record.results.to_string();
 
         debug!("GDB output: {}", output);
         Ok(record)
@@ -223,7 +219,7 @@ impl GDBManager {
         )
         .await
         {
-            Ok(Ok(result)) => Ok(result.results.dump()),
+            Ok(Ok(result)) => Ok(result.results.to_string()),
             Ok(Err(e)) => Err(e),
             Err(_) => Err(AppError::GDBTimeout),
         }

--- a/src/mi/mod.rs
+++ b/src/mi/mod.rs
@@ -278,6 +278,14 @@ impl GDB {
 
     pub async fn is_session_active(&mut self) -> AppResult<bool> {
         let res = self.execute(commands::MiCommand::thread_info(None)).await?;
-        Ok(!res.results["threads"].is_empty())
+        if let Some(threads) = res.results.get("threads") {
+            if let Some(threads) = threads.as_array() {
+                Ok(!threads.is_empty())
+            } else {
+                Err(AppError::GDBError("threads is not an array".to_string()))
+            }
+        } else {
+            Err(AppError::GDBError("threads is not found".to_string()))
+        }
     }
 }


### PR DESCRIPTION
use serde_json instead which is also used in the MCP SDK so we can save the type conversion overhead

Signed-off-by: Lix Zhou <xeontz@gmail.com>