### PR TITLE
fix: move busy polling to the background thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A GDB/MI protocol server based on the MCP protocol, providing remote application
 - View stack information and variables
 - Control program execution (run, pause, step, etc.)
 - Support concurrent multi-session debugging
+- A built-in TUI to inspect agent behaviors so that you can improve your prompt
 
 ## Installation
 


### PR DESCRIPTION
reduce non-response time in the main tokio async context

Signed-off-by: Lix Zhou <xeontz@gmail.com>