### PR TITLE
fix: found root cause why key events can be lost

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A GDB/MI protocol server based on the MCP protocol, providing remote application
 - View stack information and variables
 - Control program execution (run, pause, step, etc.)
 - Support concurrent multi-session debugging
-- A built-in TUI to inspect agent behaviors so that you can improve your prompt
+- A built-in TUI to inspect agent behaviors so that you can improve your prompt (WIP)
 
 ## Installation
 

--- a/src/bin/gdb_client.rs
+++ b/src/bin/gdb_client.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
         TransportType::Stdio => {
             let transport = ClientStdioTransport::new(
                 "./target/debug/mcp-server-gdb",
-                &["--log-level", "debug", "--disable-tui"],
+                &["--log-level", "debug"],
             )?;
             let client = ClientBuilder::new(transport).build();
 


### PR DESCRIPTION
Part of key inputs are sent to stdio MCP server so key events can be eaten and lost. Don't allow stdio to work with TUI.

Signed-off-by: Lix Zhou <xeontz@gmail.com>